### PR TITLE
multipart/form-data upload support (fixed)

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -1172,11 +1172,11 @@ qq.extend(qq.UploadHandlerForm.prototype, {
         this.log("innerHTML = " + innerHTML);
         //plain text response may be wrapped in <pre> tag
         if (innerHTML.slice(0, 5).toLowerCase() == '<pre>' && innerHTML.slice(-6).toLowerCase() == '</pre>') {
-            innerHTML = doc.body.firstChild.innerText;
+          innerHTML = doc.body.firstChild.firstChild.nodeValue;
         }
 
         try {
-            response = eval("(" + doc.body.innerHTML + ")");
+            response = eval("(" + innerHTML + ")");
         } catch(err){
             response = {};
         }        


### PR DESCRIPTION
Uses FormData api in supporting browsers to upload files in the more commonly accepted "multipart/form-data" encoding type. This is not the default behaviour for the uploader. Specify {encoding: 'multipart'} in the options when instantiating the uploader to enable this.

For iFrame uploads adds support for json response with "content-type: text/plain" so we don't have to html-encode the response.
