### PR TITLE
Fix file size check under Chrome, FF, IE9+ and other modern browsers.

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -445,8 +445,9 @@ qq.FileUploaderBasic.prototype = {
         } else {
             // fix missing properties in Safari 4 and firefox 11.0a2
             name = (file.fileName !== null && file.fileName !== undefined) ? file.fileName : file.name;
-            size = file.fileSize !== null ? file.fileSize : file.size;
         }
+        
+        size = (file.fileSize !== null && file.fileSize !== undefined) ? file.fileSize : file.size;
                     
         if (! this._isAllowedExtension(name)){            
             this._error('typeError', name);


### PR DESCRIPTION
When a `file` arrives at `_validateFile` function it will contain `size` property, holding number of bytes. The function checked `fileSize` property against null and used `undefined` as file size. After this fix, size checks will work on latest Chrome, Firefox and IE9+
