### PR TITLE
Fix for simultaneous uploads appearing to hang.

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -1096,6 +1096,7 @@ qq.UploadHandlerForm = function(o){
 qq.extend(qq.UploadHandlerForm.prototype, qq.UploadHandlerAbstract.prototype);
 
 qq.extend(qq.UploadHandlerForm.prototype, {
+	_detach_event: new Object(),
     add: function(fileInput){
         fileInput.setAttribute('name', this._options.inputName);
         var id = 'qq-upload-handler-iframe' + qq.getUniqueId();       
@@ -1154,7 +1155,8 @@ qq.extend(qq.UploadHandlerForm.prototype, {
             delete self._inputs[id];
             // timeout added to fix busy state in FF3.6
             setTimeout(function(){
-                self._detach_event();
+                self._detach_event[iframe.id]();
+				delete self._detach_event[iframe.id];
                 qq.remove(iframe);
             }, 1);
         });
@@ -1165,7 +1167,7 @@ qq.extend(qq.UploadHandlerForm.prototype, {
         return id;
     }, 
     _attachLoadEvent: function(iframe, callback){
-        this._detach_event = qq.attach(iframe, 'load', function(){
+        this._detach_event[iframe.id] = qq.attach(iframe, 'load', function(){
             // when we remove iframe from dom
             // the request stops, but in IE load
             // event fires


### PR DESCRIPTION
Fix for a concurrency issue. When multiple file uploaders exist on the same page, and a second file is uploaded while the first is still pending, the second file would appear to get stuck in pending state indefinitely (even though the server had responded successfully). This was because the first uploader was inadvertantly removing the load event handler from the second file's iframe, not its own. This change allows multiple detach events to be maintained, if multiple files are pending simultaneously.
