### PR TITLE
Fix NaN CSS filter in IE

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -136,7 +136,7 @@ qq.toElement = (function(){
  * Fixes opacity in IE6-8.
  */
 qq.css = function(element, styles){
-    if (styles.opacity != null){
+    if (styles.opacity != null && typeof styles.opacity != 'undefined'){
         if (typeof element.style.opacity != 'string' && typeof(element.filters) != 'undefined'){
             styles.filter = 'alpha(opacity=' + Math.round(100 * styles.opacity) + ')';
         }


### PR DESCRIPTION
Prior to this commit, if styles.opacity was undefined,
the qq.css() function would generate an IE filter with
opacity=NaN, which caused other styles to fail to display
correctly.
