### PR TITLE
Allow a hook in _onInputChange

### DIFF
--- a/client/fileuploader.js
+++ b/client/fileuploader.js
@@ -409,11 +409,13 @@ qq.FileUploaderBasic.prototype = {
     _onUpload: function(id, fileName, xhr){
     },
     _onInputChange: function(input){
-        if (this._handler instanceof qq.UploadHandlerXhr){
-            this._uploadFileList(input.files);
-        } else {
-            if (this._validateFile(input)){
-                this._uploadFile(input);
+        if(!this._options.onInputChange || this._options.onInputChange(input)) {
+            if (this._handler instanceof qq.UploadHandlerXhr){
+                this._uploadFileList(input.files);
+            } else {
+                if (this._validateFile(input)){
+                    this._uploadFile(input);
+                }
             }
         }
         this._button.reset();


### PR DESCRIPTION
There was a need of controlling number of images that can be uploaded, and the logic needed to take number of images selected using the file input as well as application state of existing number of images. After studying the logic, it appeared that the _onInputChange event handler is the best place for calling an application-provided hook/callback like onComplete and others.

Changes are as follows:
1  In ```_onInputChange```, proceed as usual if application specific ```this._options.onInputChange``` is not provided
2  If ```this._options.onInputChange``` is provided, call it as ```this._options.onInputChange(input)``` and expect a boolean return value
3  If the return value is ```true``` proceed with usual flow of uploading, otherwise do not.

How users are impacted/can use this:

1  Existing client applications are not impacted
2  To use this hook, add the ```onInputChange``` option to the options provided to create the uploader object as follows:
```
onInputChange: function(input) {
    // .. your app logic
    if(...) {
        return(true);
    } else {
        return(false);
    }
}
```